### PR TITLE
Changes ipparam by linkname ppp variable to rename interfaces. Bug-Id 14...

### DIFF
--- a/lib/Vyatta/L2TPConfig.pm
+++ b/lib/Vyatta/L2TPConfig.pm
@@ -489,7 +489,7 @@ EOS
   my $str =<<EOS;
 $cfg_delim_begin
 name xl2tpd
-ipparam l2tp
+linkname l2tp
 ipcp-accept-local
 ipcp-accept-remote
 ${sstr}noccp

--- a/lib/Vyatta/PPTPConfig.pm
+++ b/lib/Vyatta/PPTPConfig.pm
@@ -268,7 +268,7 @@ EOS
   my $str =<<EOS;
 $cfg_delim_begin
 name pptpd
-ipparam pptp
+linkname pptp
 refuse-pap
 refuse-chap
 refuse-mschap
@@ -398,7 +398,6 @@ sub get_pptp_conf {
 $cfg_delim_begin
 option $ppp_opts
 ${listen}debug
-noipparam
 #logwtmp
 localip 10.255.254.0
 remoteip $ip_str

--- a/scripts/rename-l2tp
+++ b/scripts/rename-l2tp
@@ -12,7 +12,7 @@
 # bounced
 
 OLD_IFNAME=$1
-IFPREFIX=$6
+IFPREFIX=$LINKNAME
 
 # We have to get a list of currently used indicies since these 
 # are dynamic interfaces

--- a/scripts/rename-pptp
+++ b/scripts/rename-pptp
@@ -12,7 +12,7 @@
 # bounced
 
 OLD_IFNAME=$1
-IFPREFIX=$6
+IFPREFIX=$LINKNAME
 
 # We have to get a list of currently used indicies since these 
 # are dynamic interfaces


### PR DESCRIPTION
Hi daniil.
This is how I should do a pull to vyos?
Bug 146 Is not yet closed, because xl2tpd 1.2.6 was ipparam bug.

Thanks.
