### PR TITLE
l2tp-remote acces authentication require options.

### DIFF
--- a/lib/Vyatta/L2TPConfig.pm
+++ b/lib/Vyatta/L2TPConfig.pm
@@ -30,6 +30,7 @@ my %fields = (
   _auth_mode        => undef,
   _mtu              => undef,
   _ike_lifetime     => undef,
+  _auth_require     => undef,
   _auth_local       => [],
   _auth_radius      => [],
   _auth_radius_keys => [],
@@ -78,6 +79,7 @@ sub setup {
   $self->{_client_ip_start} = $config->returnValue('client-ip-pool start');
   $self->{_client_ip_stop} = $config->returnValue('client-ip-pool stop');
   $self->{_auth_mode} = $config->returnValue('authentication mode');
+  $self->{_auth_require} = $config->returnValue('authentication require');
   $self->{_mtu} = $config->returnValue('mtu');
 
   my @users = $config->listNodes('authentication local-users username');
@@ -156,6 +158,7 @@ sub setupOrig {
   $self->{_client_ip_start} = $config->returnOrigValue('client-ip-pool start');
   $self->{_client_ip_stop} = $config->returnOrigValue('client-ip-pool stop');
   $self->{_auth_mode} = $config->returnOrigValue('authentication mode');
+  $self->{_auth_require} = $config->returnValue('authentication require');
   $self->{_mtu} = $config->returnOrigValue('mtu');
 
   my @users = $config->listOrigNodes('authentication local-users username');
@@ -240,6 +243,7 @@ sub isDifferentFrom {
   return 1 if ($this->{_client_ip_start} ne $that->{_client_ip_start});
   return 1 if ($this->{_client_ip_stop} ne $that->{_client_ip_stop});
   return 1 if ($this->{_auth_mode} ne $that->{_auth_mode});
+  return 1 if ($this->{_auth_require} ne $that->{_auth_require});
   return 1 if ($this->{_mtu} ne $that->{_mtu});
   return 1 if (listsDiff($this->{_auth_local}, $that->{_auth_local}));
   return 1 if (listsDiff($this->{_auth_radius}, $that->{_auth_radius}));
@@ -502,6 +506,9 @@ lock
 proxyarp
 connect-delay 5000
 EOS
+  if (defined ($self->{_auth_require})){
+    $str .= "require-".$self->{_auth_require}."\n";
+  }
   if (defined ($self->{_mtu})){
     $str .= "mtu $self->{_mtu}\n"
          .  "mru $self->{_mtu}\n";

--- a/templates-cfg/vpn/l2tp/remote-access/authentication/require/node.def
+++ b/templates-cfg/vpn/l2tp/remote-access/authentication/require/node.def
@@ -1,7 +1,7 @@
 type: txt
 help: Authentication protocol for remote access peer L2TP VPN
 syntax:expression: $VAR(@) in "pap", "chap", "mschap", "mschap-v2"; "Authentication protocol must be \"pap\", \"chap\", \"mschap\" or \"mschap-v2\""
-val_help: pap;Require the peer to authenticate itself using PAP [Password Authentication Protocol] authentication. 
-val_help: chap;Require the peer to authenticate itself using CHAP [Challenge Handshake Authentication Protocol] authentication. 
-val_help: mschap;Require the peer to authenticate itself using MS-CHAP [Microsoft Challenge Handshake Authentication Protocol] authentication. 
-val_help: mschap-v2;Require the peer to authenticate itself using MS-CHAPv2 [Microsoft Challenge Handshake Authentication Protocol, Version 2] authentication. 
+val_help: pap;Require the peer to authenticate itself using PAP [Password Authentication Protocol]. 
+val_help: chap;Require the peer to authenticate itself using CHAP [Challenge Handshake Authentication Protocol]. 
+val_help: mschap;Require the peer to authenticate itself using MS-CHAP [Microsoft Challenge Handshake Authentication Protocol]. 
+val_help: mschap-v2;Require the peer to authenticate itself using MS-CHAPv2 [Microsoft Challenge Handshake Authentication Protocol, Version 2]. 

--- a/templates-cfg/vpn/l2tp/remote-access/authentication/require/node.def
+++ b/templates-cfg/vpn/l2tp/remote-access/authentication/require/node.def
@@ -1,0 +1,7 @@
+type: txt
+help: Authentication protocol for remote access peer L2TP VPN
+syntax:expression: $VAR(@) in "pap", "chap", "mschap", "mschap-v2"; "Authentication protocol must be \"pap\", \"chap\", \"mschap\" or \"mschap-v2\""
+val_help: pap;Require the peer to authenticate itself using PAP [Password Authentication Protocol] authentication. 
+val_help: chap;Require the peer to authenticate itself using CHAP [Challenge Handshake Authentication Protocol] authentication. 
+val_help: mschap;Require the peer to authenticate itself using MS-CHAP [Microsoft Challenge Handshake Authentication Protocol] authentication. 
+val_help: mschap-v2;Require the peer to authenticate itself using MS-CHAPv2 [Microsoft Challenge Handshake Authentication Protocol, Version 2] authentication. 


### PR DESCRIPTION
Hi daniil, I added require autentication  options to ppp/options.xl2tp and force aut protocol to pap|chap|mschap|mschap-v2 (don't added eap because I don't tested it) 
Also, options.pptp don't need this because has has a require mschap-v2
The shortest way should be add directly require mschap-v2 to options.xl2tp, but to mantain compatibility with previous installations I created this mod.

Let me know if I you prefer that auth options in xl2tp would be like auth options.pptp
Skeleton was:
vpn {
    l2tp {
        remote-access {
            authentication {
                mode radius
                radius-server 10.15.8.2 {
                    key ****************
                }
                  require mschap-v2 <-------chap,pap,....
