### PR TITLE
T434: Fix RADIUS client authentication

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+vyatta-ravpn (0.12.45+vyos2+current1) current; urgency=medium
+
+  [ Christian Poessinger ]
+  * Fix radiusclient folder after migration to libfreeradius-client2
+
+ -- Christian Poessinger <christian@poessinger.com>  Fri, 01 Dec 2017 18:00:00 +0100
+
 vyatta-ravpn (0.12.45+vyos2+current1) lithium; urgency=medium
 
   [ Thomas Jepp ]

--- a/debian/vyatta-ravpn.postinst.in
+++ b/debian/vyatta-ravpn.postinst.in
@@ -14,11 +14,11 @@ done
 sed '1,/start-stop-daemon/s/start-stop-daemon --start/start-stop-daemon --start --oknodo/' -i /etc/init.d/xl2tpd
 
 for cfg in /etc/ipsec.d/tunnels/remote-access \
-           /etc/radiusclient-ng/radiusclient-pptp.conf \
-           /etc/radiusclient-ng/servers-pptp \
-           /etc/radiusclient-ng/radiusclient-l2tp.conf \
-           /etc/radiusclient-ng/servers-l2tp \
-           /etc/radiusclient-ng/port-id-map-ravpn \
+           /etc/radiusclient/radiusclient-pptp.conf \
+           /etc/radiusclient/servers-pptp \
+           /etc/radiusclient/radiusclient-l2tp.conf \
+           /etc/radiusclient/servers-l2tp \
+           /etc/radiusclient/port-id-map-ravpn \
            /etc/ppp/secrets/chap-ravpn \
            /etc/ppp/options.xl2tpd \
            /etc/ppp/options.pptpd; do
@@ -37,12 +37,12 @@ fi
 chmod 600 /etc/ppp/secrets/chap-ravpn
 
 cp -f ${sysconfdir}/ravpn/radius-dictionary.microsoft \
-  /etc/radiusclient-ng/dictionary.microsoft
-cp -f /etc/radiusclient-ng/dictionary /etc/radiusclient-ng/dictionary-ravpn
-echo 'INCLUDE /etc/radiusclient-ng/dictionary.merit' \
-  >> /etc/radiusclient-ng/dictionary-ravpn
-echo 'INCLUDE /etc/radiusclient-ng/dictionary.microsoft' \
-  >> /etc/radiusclient-ng/dictionary-ravpn
+  /etc/radiusclient/dictionary.microsoft
+cp -f /etc/radiusclient/dictionary /etc/radiusclient/dictionary-ravpn
+echo 'INCLUDE /etc/radiusclient/dictionary.merit' \
+  >> /etc/radiusclient/dictionary-ravpn
+echo 'INCLUDE /etc/radiusclient/dictionary.microsoft' \
+  >> /etc/radiusclient/dictionary-ravpn
 
 mkdir -p ${sysconfdir}/ravpn/sessions
 

--- a/lib/Vyatta/L2TPConfig.pm
+++ b/lib/Vyatta/L2TPConfig.pm
@@ -505,7 +505,7 @@ sub get_ppp_opts {
   if ($self->{_auth_mode} eq 'radius') {
     $rstr =<<EOS;
 plugin radius.so
-radius-config-file /etc/radiusclient-ng/radiusclient-l2tp.conf
+radius-config-file /etc/radiusclient/radiusclient-l2tp.conf
 plugin radattr.so
 EOS
   }
@@ -561,12 +561,12 @@ auth_order      radius
 login_tries     4
 login_timeout   60
 nologin /etc/nologin
-issue   /etc/radiusclient-ng/issue
-${authstr}${acctstr}servers         /etc/radiusclient-ng/servers-l2tp
-dictionary      /etc/radiusclient-ng/dictionary-ravpn
+issue   /etc/radiusclient/issue
+${authstr}${acctstr}servers         /etc/radiusclient/servers-l2tp
+dictionary      /etc/radiusclient/dictionary-ravpn
 login_radius    /usr/sbin/login.radius
 seqfile         /var/run/radius.seq
-mapfile         /etc/radiusclient-ng/port-id-map-ravpn
+mapfile         /etc/radiusclient/port-id-map-ravpn
 default_realm
 radius_timeout  10
 radius_retries  3

--- a/lib/Vyatta/PPTPConfig.pm
+++ b/lib/Vyatta/PPTPConfig.pm
@@ -266,7 +266,7 @@ sub get_ppp_opts {
   if ($self->{_auth_mode} eq 'radius') {
     $rstr =<<EOS;
 plugin radius.so
-radius-config-file /etc/radiusclient-ng/radiusclient-pptp.conf
+radius-config-file /etc/radiusclient/radiusclient-pptp.conf
 plugin radattr.so
 EOS
   }
@@ -324,12 +324,12 @@ auth_order      radius
 login_tries     4
 login_timeout   60
 nologin /etc/nologin
-issue   /etc/radiusclient-ng/issue
-${authstr}${acctstr}servers         /etc/radiusclient-ng/servers-pptp
-dictionary      /etc/radiusclient-ng/dictionary-ravpn
+issue   /etc/radiusclient/issue
+${authstr}${acctstr}servers         /etc/radiusclient/servers-pptp
+dictionary      /etc/radiusclient/dictionary-ravpn
 login_radius    /usr/sbin/login.radius
 seqfile         /var/run/radius.seq
-mapfile         /etc/radiusclient-ng/port-id-map-ravpn
+mapfile         /etc/radiusclient/port-id-map-ravpn
 default_realm
 radius_timeout  10
 radius_retries  3

--- a/scripts/vyatta-update-l2tp.pl
+++ b/scripts/vyatta-update-l2tp.pl
@@ -16,8 +16,8 @@ my $FILE_CHAP_SECRETS = '/etc/ppp/secrets/chap-ravpn';
 my $FILE_PPP_OPTS = '/etc/ppp/options.xl2tpd';
 my $FILE_L2TP_OPTS = '/etc/xl2tpd/xl2tpd.conf';
 my $IPSEC_CTL_FILE = '/var/run/charon.ctl';
-my $FILE_RADIUS_CONF = '/etc/radiusclient-ng/radiusclient-l2tp.conf';
-my $FILE_RADIUS_KEYS = '/etc/radiusclient-ng/servers-l2tp';
+my $FILE_RADIUS_CONF = '/etc/radiusclient/radiusclient-l2tp.conf';
+my $FILE_RADIUS_KEYS = '/etc/radiusclient/servers-l2tp';
 my $FILE_DHCP_HOOK = '/etc/dhcp/dhclient-exit-hooks.d/l2tpd';
 
 my $gconfig = new Vyatta::Config;

--- a/scripts/vyatta-update-pptp.pl
+++ b/scripts/vyatta-update-pptp.pl
@@ -8,8 +8,8 @@ my $FILE_CHAP_SECRETS = '/etc/ppp/secrets/chap-ravpn';
 my $FILE_PPP_OPTS = '/etc/ppp/options.pptpd';
 my $FILE_PPTP_OPTS = '/etc/pptpd.conf';
 my $PPTP_INIT = '/etc/init.d/pptpd';
-my $FILE_RADIUS_CONF = '/etc/radiusclient-ng/radiusclient-pptp.conf';
-my $FILE_RADIUS_KEYS = '/etc/radiusclient-ng/servers-pptp';
+my $FILE_RADIUS_CONF = '/etc/radiusclient/radiusclient-pptp.conf';
+my $FILE_RADIUS_KEYS = '/etc/radiusclient/servers-pptp';
 my $FILE_DHCP_SCRIPT = '/etc/dhcp/dhclient-exit-hooks.d/pptpd';
 
 my $config = new Vyatta::PPTPConfig;


### PR DESCRIPTION
Commit eadb8c687dd1("Change libradiusclient-ng2 to libfreeradius-client2.")
changed the radiusclient which is used during authentication. This change was
required by the 'squeeze' -> 'jessie' upgrade.

"libradiusclient-ng2" used the configuration filers from /etc/radiusclient-ng,
but "libfreeradius-client2" now uses "/etc/radiusclient".

Paths have been adjusted using:
  sed -i s@/etc/radiusclient-ng@/etc/radiusclient@g <file>