### PR TITLE
[IPsec] T1605: Remove unique XFRM marking

### DIFF
--- a/lib/Vyatta/L2TPConfig.pm
+++ b/lib/Vyatta/L2TPConfig.pm
@@ -441,7 +441,6 @@ conn $name
   left=$oaddr
   leftsubnet=%dynamic[/1701]
   rightsubnet=%dynamic
-  mark=%unique
   auto=add
   ike=aes256-sha1-modp1024,3des-sha1-modp1024,3des-sha1-modp1024!
   dpddelay=15


### PR DESCRIPTION
L2tp over IPsec is not working in VyOS 1.2.0 without configured NAT.

https://phabricator.vyos.net/T1605