### PR TITLE
vyatta-ravpn: T3111: Changed the permissions of the file chap-secrets to read only.

### DIFF
--- a/scripts/vyatta-update-l2tp.pl
+++ b/scripts/vyatta-update-l2tp.pl
@@ -110,7 +110,7 @@ exit 1 if (!$config->writeCfg($FILE_L2TP_OPTS, $l2tp_conf, 0, 0));
 exit 1 if (!$config->writeCfg($FILE_RADIUS_CONF, $radius_conf, 0, 0));
 exit 1 if (!$config->writeCfg($FILE_RADIUS_KEYS, $radius_keys, 0, 0));
 
-system('cat /etc/ppp/secrets/chap-* > /etc/ppp/chap-secrets');
+system('cat /etc/ppp/secrets/chap-* > /etc/ppp/chap-secrets && chmod 600 /etc/ppp/chap-secrets');
 if ($? >> 8) {
   print STDERR <<EOM;
 L2TP VPN configuration error: Cannot write chap-secrets.

--- a/scripts/vyatta-update-pptp.pl
+++ b/scripts/vyatta-update-pptp.pl
@@ -68,7 +68,7 @@ exit 1 if (!$config->writeCfg($FILE_PPTP_OPTS, $pptp_conf, 0, 0));
 exit 1 if (!$config->writeCfg($FILE_RADIUS_CONF, $radius_conf, 0, 0));
 exit 1 if (!$config->writeCfg($FILE_RADIUS_KEYS, $radius_keys, 0, 0));
 
-system('cat /etc/ppp/secrets/chap-* > /etc/ppp/chap-secrets');
+system('cat /etc/ppp/secrets/chap-* > /etc/ppp/chap-secrets && chmod 600 /etc/ppp/chap-secrets');
 if ($? >> 8) {
   print STDERR <<EOM;
 PPTP VPN configuration error: Cannot write chap-secrets.


### PR DESCRIPTION
Changes are made in the file "/opt/vyatta/sbin/vyatta-update-pptp.pl and
/opt/vyatta/sbin/vyatta-update-l2tp.pl Removed the permission of the others and all groups for the file /etc/ppp/chap-secrets
Only the user should have the read/write permissions
