### PR TITLE
l2tp-server: T2954: Delete deprecated params

### DIFF
--- a/lib/Vyatta/L2TPConfig.pm
+++ b/lib/Vyatta/L2TPConfig.pm
@@ -524,10 +524,8 @@ ipcp-accept-local
 ipcp-accept-remote
 ${sstr}noccp
 auth
-crtscts
 nodefaultroute
 debug
-lock
 proxyarp
 connect-delay 5000
 EOS


### PR DESCRIPTION
These changes required for the new xl2tpd (1.3.16) version